### PR TITLE
chore: update social links and optimize images

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -96,8 +96,8 @@ export default function RootLayout({
                 "I build automation and analytics tools that help creators earn more with less work.",
               url: siteUrl,
               sameAs: [
-                "https://github.com/philgreene",
-                "https://linkedin.com/in/philgreene",
+                "https://github.com/WebCraftPhil",
+                "https://linkedin.com/in/phil.greene1",
               ],
               knowsAbout: [
                 "Creator Automation",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -21,10 +21,22 @@ export default function Footer() {
             <a href="mailto:hello@philgreene.net" className="text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" aria-label="Email">
               <Mail className="h-5 w-5" />
             </a>
-            <a href="https://github.com/philgreene" target="_blank" rel="noopener noreferrer" className="text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" aria-label="GitHub">
+            <a
+              href="https://github.com/WebCraftPhil"
+              target="_blank"
+              rel="me noopener noreferrer"
+              className="text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+              aria-label="GitHub"
+            >
               <Github className="h-5 w-5" />
             </a>
-            <a href="https://www.linkedin.com/in/phil-greene" target="_blank" rel="noopener noreferrer" className="text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400" aria-label="LinkedIn">
+            <a
+              href="https://www.linkedin.com/in/phil.greene1"
+              target="_blank"
+              rel="me noopener noreferrer"
+              className="text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+              aria-label="LinkedIn"
+            >
               <Linkedin className="h-5 w-5" />
             </a>
           </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -30,6 +30,9 @@ export default function ProjectCard({ project, variant = 'default' }: ProjectCar
           src={project.screenshot}
           alt={`${project.title} screenshot`}
           fill
+          priority={isFeatured}
+          loading={isFeatured ? "eager" : "lazy"}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           className="object-cover transition-transform duration-300 group-hover:scale-105"
         />
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/30 via-black/0 to-transparent opacity-60" />


### PR DESCRIPTION
## Summary
- point footer GitHub and LinkedIn icons to WebCraftPhil and Phil.greene1 profiles
- reflect new profile URLs in layout structured data
- improve project card image performance with lazy loading and responsive sizing

## Testing
- `npm run format` *(fails: Missing script "format")*
- `npm run lint`
- `npm run build`
- `npm test`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68b6eba53980832794c2b4a704189aa5