### PR TITLE
fix: remove conflicting domain redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ npm run lint
 
 ### Adding a Project
 
-1) Add a new object to `projects` in `philgreene-net-fresh/lib/projects.ts#L1`.
-2) Provide a unique `id` and `slug`, `title`, `description`, `role`, `stack`, `outcomes`, `category`, `featured`, and `screenshot` path.
-3) Optionally add a case study entry in `caseStudies` if you want deeper details.
+1. Add a new object to `projects` in `philgreene-net-fresh/lib/projects.ts#L1`.
+2. Provide a unique `id` and `slug`, `title`, `description`, `role`, `stack`, `outcomes`, `category`, `featured`, and `screenshot` path.
+3. Optionally add a case study entry in `caseStudies` if you want deeper details.
 
 ## Pages Overview
 
@@ -107,7 +107,9 @@ Recommended: Vercel
 - Build command: `next build` (uses Turbopack flag in package script)
 - Install command: `npm install`
 - Output: `.next` (default)
-- Ensure the Vercel project uses `philgreene.net` as the primary domain with `www` redirect so `_next/static/*` assets resolve correctly.
+- Use a single primary domain in your hosting provider and avoid conflicting
+  redirects between `philgreene.net` and `www.philgreene.net` to prevent redirect
+  loops.
 
 No special `next.config.ts` options are required for a basic deployment.
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,16 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   assetPrefix: process.env.NEXT_PUBLIC_ASSET_PREFIX || undefined,
-  async redirects() {
-    return [
-      {
-        source: '/:path*',
-        has: [{ type: 'host', value: 'www.philgreene.net' }],
-        destination: 'https://philgreene.net/:path*',
-        permanent: true,
-      },
-    ];
-  },
+  // Domain-level redirects are handled by the hosting platform to
+  // avoid redirect loops between `www` and the apex domain.
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove Next.js host-based redirect causing `philgreene.net` ↔ `www.philgreene.net` loop
- document avoiding conflicting domain redirects in deployment

## Testing
- `npx prettier --write next.config.ts README.md`
- `npm run lint` *(fails: Invalid package.json)*
- `npm run build` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68bac530d2e883278e00a9c195b79b43