### PR TITLE
Add ROI-focused services packages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,60 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://philgreene.net";
 
 export default function Home() {
   const featuredProjects = getFeaturedProjects();
+  const services = [
+    {
+      title: "Revenue Validation Sprint",
+      price: "from $1,250",
+      description:
+        "Fast-track your offer, landing page, and analytics so you can see if revenue is ready to scale.",
+      features: [
+        "Launch-ready landing page with tracking in 14 days",
+        "Offer + positioning tuned to buyer intent",
+        "Proof-of-revenue dashboard you can share with stakeholders",
+      ],
+      accent: "#28965a",
+      icon: "🚀",
+    },
+    {
+      title: "Automation & AI Ops",
+      price: "from $1,800",
+      description:
+        "Remove manual busywork with custom automations and AI workflows that keep quality high.",
+      features: [
+        "Workflow audit to prioritize ROI-positive automations",
+        "Custom GPT + no-code flows for content, ops, and customer success",
+        "Runbook, monitoring, and team handoff included",
+      ],
+      accent: "#e09f3e",
+      icon: "🤖",
+    },
+    {
+      title: "Conversion & Insights Engine",
+      price: "from $1,400",
+      description:
+        "Turn your data into guardrails: clean tracking, dashboards, and experiments that lift revenue.",
+      features: [
+        "KPI instrumentation across web, product, and revenue events",
+        "Dashboards with weekly signal reports and next best actions",
+        "A/B tests and funnel fixes targeting 20–30% lift",
+      ],
+      accent: "#33658a",
+      icon: "📊",
+    },
+    {
+      title: "MVP to Launch (Full Stack)",
+      price: "from $4,500",
+      description:
+        "Design, build, and ship a production-ready MVP with telemetry, payments, and onboarding baked in.",
+      features: [
+        "Scope, UX, and architecture aligned to revenue milestones",
+        "Auth, billing, and usage analytics wired from day one",
+        "Launch playbook plus onboarding and lifecycle assets",
+      ],
+      accent: "#c6f91f",
+      icon: "💻",
+    },
+  ];
 
   return (
     <div className="min-h-screen">
@@ -275,52 +329,51 @@ export default function Home() {
       </section>
 
       {/* Services Section */}
-      <section id="services" className="py-20">
+      <section id="services" className="py-20 bg-muted/60">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="mb-12 text-center">
             <h2 className="text-gradient-coolors text-3xl font-bold sm:text-4xl">
-              What I Do
+              4 Services Focused on Your ROI.
             </h2>
-            <p className="mt-4 text-lg text-muted-foreground">
-              Comprehensive solutions for data-driven businesses
+            <p className="mt-4 text-lg text-muted-foreground max-w-3xl mx-auto">
+              Clear packages, transparent starter pricing, and deliverables that ship revenue-ready assets—not just tasks.
             </p>
           </div>
 
-          <div className="grid gap-8 md:grid-cols-3">
-            <div className="card card-hover border-[#28965a]/20 hover:border-[#28965a]/40">
-              <div className="mb-4 text-3xl">📈</div>
-              <h3 className="mb-2 text-xl font-semibold text-card-foreground">
-                Data Analysis & BI
-              </h3>
-              <p className="text-muted-foreground">
-                Transform raw data into actionable insights with custom
-                dashboards, predictive modeling, and automated reporting
-                systems.
-              </p>
-            </div>
-
-            <div className="card card-hover border-[#e09f3e]/20 hover:border-[#e09f3e]/40">
-              <div className="mb-4 text-3xl">🤖</div>
-              <h3 className="mb-2 text-xl font-semibold text-card-foreground">
-                AI & Automation
-              </h3>
-              <p className="text-muted-foreground">
-                Build intelligent systems that automate workflows, analyze
-                documents, and optimize business processes using cutting-edge AI
-                technologies.
-              </p>
-            </div>
-
-            <div className="card card-hover border-[#33658a]/20 hover:border-[#33658a]/40">
-              <div className="mb-4 text-3xl">💻</div>
-              <h3 className="mb-2 text-xl font-semibold text-card-foreground">
-                Full Stack Development
-              </h3>
-              <p className="text-muted-foreground">
-                Create scalable web applications from concept to deployment,
-                with modern frameworks and cloud-native architectures.
-              </p>
-            </div>
+          <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+            {services.map((service) => (
+              <div
+                key={service.title}
+                className="card card-hover flex flex-col h-full"
+                style={{ borderColor: `${service.accent}33` }}
+              >
+                <div className="flex items-start justify-between mb-4">
+                  <div className="text-3xl" aria-hidden>
+                    {service.icon}
+                  </div>
+                  <span
+                    className="rounded-full px-3 py-1 text-sm font-semibold"
+                    style={{ backgroundColor: `${service.accent}1a`, color: service.accent }}
+                  >
+                    {service.price}
+                  </span>
+                </div>
+                <h3 className="mb-2 text-xl font-semibold text-card-foreground">
+                  {service.title}
+                </h3>
+                <p className="text-muted-foreground mb-6">{service.description}</p>
+                <ul className="space-y-2 mt-auto">
+                  {service.features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2 text-sm text-card-foreground">
+                      <span className="mt-0.5 text-lg" aria-hidden>
+                        ✓
+                      </span>
+                      <span className="text-muted-foreground">{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/docs/agents/ledger.json
+++ b/docs/agents/ledger.json
@@ -29,8 +29,7 @@
       "Created SVG placeholder images for project screenshots"
     ],
     "fingerprint": "portfolio-features-v1"
-  }
-  ,
+  },
   {
     "id": "20250903-0130-navigation-cta-seo",
     "actor": "agent:cursor",
@@ -66,5 +65,25 @@
       "Enabled site crawling via robots.txt"
     ],
     "fingerprint": "eb7b066070a67ad51eb0a999f02e31f8debd326b2918d588adf48c787ec3c405"
+  },
+  {
+    "id": "20251123-2319-roi-services-packages",
+    "actor": "agent:cursor",
+    "intent": "add ROI-focused services section with four packages and pricing",
+    "inputs": {
+      "sectionTitle": "4 Services Focused on Your ROI.",
+      "serviceCount": 4
+    },
+    "relatedFiles": [
+      "app/page.tsx"
+    ],
+    "status": "done",
+    "evidence": "npm run lint (warnings), CI=1 npm run build, npm test, npm audit (1 moderate vulnerability remains)",
+    "notes": [
+      "Replaced services section with ROI-focused packages",
+      "Added pricing chips and deliverable lists",
+      "Audit reports existing moderate js-yaml vulnerability"
+    ],
+    "fingerprint": "1fd99d0cc05e609cae62e4cc74fcccad09d68086691d2a1c30f490fb52300dab"
   }
 ]


### PR DESCRIPTION
## Summary
- add an ROI-focused services section featuring four priced packages on the homepage
- include pricing chips and deliverable lists to make the services easy to scan
- log the work in the agent ledger for traceability

## Testing
- npm run lint
- CI=1 npm run build > /tmp/build.log && tail -n 20 /tmp/build.log
- npm test
- npm audit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923956ac2548327bc1c38a6d705dc95)