### PR TITLE
Store Contact Form Submissions in Database

### DIFF
--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,4 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { db } from '../server/db';
+import { contactSubmissions } from '../shared/schema';
 import { sendEmail } from '../server/sendgrid';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -31,6 +33,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         error: 'Message must be at least 10 characters long' 
       });
     }
+
+    // Save submission to the database
+    await db.insert(contactSubmissions).values({
+      name,
+      email,
+      message,
+      projectType,
+      budget,
+    });
 
     // Send email notification to me@philgreene.net
     const emailSent = await sendEmail({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, text, varchar } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -9,10 +9,40 @@ export const users = pgTable("users", {
   password: text("password").notNull(),
 });
 
-export const insertUserSchema = createInsertSchema(users).pick({
+export const insertUserSchema = createInsertschema(users).pick({
   username: true,
   password: true,
 });
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
+
+export const contactSubmissions = pgTable("contact_submissions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  email: text("email").notNull(),
+  message: text("message").notNull(),
+  projectType: text("project_type"),
+  budget: text("budget"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertContactSubmissionSchema = createInsertSchema(contactSubmissions);
+
+export type InsertContactSubmission = z.infer<typeof insertContactSubmissionSchema>;
+export type ContactSubmission = typeof contactSubmissions.$inferSelect;
+
+export const contactSubmissions = pgTable("contact_submissions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  email: text("email").notNull(),
+  message: text("message").notNull(),
+  projectType: text("project_type"),
+  budget: text("budget"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+export const insertContactSubmissionSchema = createInsertSchema(contactSubmissions);
+
+export type InsertContactSubmission = z.infer<typeof insertContactSubmissionSchema>;
+export type ContactSubmission = typeof contactSubmissions.$inferSelect;


### PR DESCRIPTION
This change adds a database backup for contact form submissions, storing them in a new `contact_submissions` table before emailing. It includes schema updates, a new database connection file, and API modifications to ensure submissions are saved reliably.

---
*PR created automatically by Jules for task [11576263443875134597](https://jules.google.com/task/11576263443875134597) started by @WebCraftPhil*

## Summary by Sourcery

Persist contact form submissions in the database alongside existing email notifications.

New Features:
- Add a contact_submissions table and associated insert/select types to the shared database schema.
- Store incoming contact form submissions in the database before sending notification emails.

Enhancements:
- Extend the shared schema module to centralize definitions for contact submission records.