### PR TITLE
[Feature] Add Privacy Policy page and footer link

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -12,6 +12,7 @@ import ProjectsSection from "@/components/ProjectsSection";
 import ContactSection from "@/components/ContactSection";
 import Footer from "@/components/Footer";
 import NotFound from "@/pages/not-found";
+import PrivacyPage from "@/pages/privacy";
 
 function HomePage() {
   const { theme, toggleTheme } = useTheme();
@@ -31,12 +32,18 @@ function HomePage() {
   );
 }
 
-function Router() {
+function AppLayout() {
+  const [location] = useLocation();
+
   return (
-    <Switch>
-      <Route path="/" component={HomePage} />
-      <Route component={NotFound} />
-    </Switch>
+    <div className="min-h-screen">
+      <Switch>
+        <Route path="/" component={HomePage} />
+        <Route path="/privacy" component={PrivacyPage} />
+        <Route component={NotFound} />
+      </Switch>
+      {location !== "/" && <Footer />}
+    </div>
   );
 }
 
@@ -46,7 +53,7 @@ function App() {
       <ThemeProvider defaultTheme="dark">
         <TooltipProvider>
           <Toaster />
-          <Router />
+          <AppLayout />
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { Link } from "wouter"
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { 
@@ -54,17 +55,33 @@ export default function Footer() {
                 { href: '#about', label: 'About' },
                 { href: '#services', label: 'Services' },
                 { href: '#projects', label: 'Projects' },
-                { href: '#contact', label: 'Contact' }
-              ].map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded"
-                  data-testid={`link-footer-${link.label.toLowerCase()}`}
-                >
-                  {link.label}
-                </a>
-              ))}
+                { href: '#contact', label: 'Contact' },
+                { href: '/privacy', label: 'Privacy Policy' }
+              ].map((link) => {
+                if (link.href.startsWith('/')) {
+                  return (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded"
+                      data-testid={`link-footer-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
+                    >
+                      {link.label}
+                    </Link>
+                  )
+                }
+
+                return (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded"
+                    data-testid={`link-footer-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
+                  >
+                    {link.label}
+                  </a>
+                )
+              })}
             </nav>
           </div>
 

--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -1,0 +1,147 @@
+export default function PrivacyPage() {
+  const effectiveDate = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date())
+
+  return (
+    <main className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Privacy Policy</h1>
+          <p className="text-muted-foreground">Effective date: {effectiveDate}</p>
+          <p className="text-muted-foreground">
+            Questions or requests? Email{' '}
+            <a className="text-primary underline" href="mailto:me@philgreene.net">
+              me@philgreene.net
+            </a>
+            .
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">1) Overview</h2>
+          <p className="text-muted-foreground">
+            This page explains what information this site may collect and how it may be used.
+            The goal is to keep this simple, clear, and honest.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">2) Information We Collect</h2>
+          <ul className="list-disc pl-6 text-muted-foreground space-y-2">
+            <li>
+              <strong>Information you provide:</strong> If you contact us through the site,
+              we may receive details such as your name, email address, project details,
+              and the message you submit.
+            </li>
+            <li>
+              <strong>Information collected automatically:</strong> Our hosting provider may
+              collect basic technical logs such as IP address, browser type, device
+              information, and request timing for security and performance.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">3) How We Use Information</h2>
+          <ul className="list-disc pl-6 text-muted-foreground space-y-2">
+            <li>To respond to messages and project inquiries.</li>
+            <li>To operate, secure, and improve the site.</li>
+            <li>To troubleshoot technical issues.</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">4) Cookies and Similar Technologies</h2>
+          <p className="text-muted-foreground">
+            This site stores a local theme preference in your browser so your light or dark
+            mode setting is remembered.
+          </p>
+          <p className="text-muted-foreground">
+            We do not intentionally use advertising cookies. Some infrastructure or embedded
+            third-party services may set cookies when required for site functionality.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">5) Analytics and Third-Party Services</h2>
+          <p className="text-muted-foreground">
+            The codebase includes optional support for analytics events with Plausible and
+            Google Analytics. Those services are only active if separately configured.
+          </p>
+          <p className="text-muted-foreground">
+            Contact form delivery may use SendGrid to send messages to the site owner. If
+            analytics or additional third-party services are added later, this policy will be
+            updated.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">6) Sharing of Information</h2>
+          <p className="text-muted-foreground">
+            Information is not sold. Information may be shared with service providers only as
+            needed to run the site and handle contact requests.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">7) Data Retention</h2>
+          <p className="text-muted-foreground">
+            Contact request details may be retained as needed to respond to your inquiry,
+            maintain records, and resolve follow-up requests.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">8) Your Choices and Rights</h2>
+          <p className="text-muted-foreground">
+            You can request access, correction, or deletion of personal information by
+            emailing me@philgreene.net.
+          </p>
+          <p className="text-muted-foreground">
+            Privacy rights can vary by location, so available rights may depend on where you
+            live.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">9) Children&apos;s Privacy</h2>
+          <p className="text-muted-foreground">
+            This site is not directed to children under 13, and we do not knowingly collect
+            personal information from children under 13.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">10) Security</h2>
+          <p className="text-muted-foreground">
+            Reasonable safeguards are used to protect information, but no online system can be
+            guaranteed to be fully secure.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">11) Changes to This Policy</h2>
+          <p className="text-muted-foreground">
+            This policy may be updated from time to time. Updates will be posted on this page
+            with a revised effective date.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">12) Contact</h2>
+          <p className="text-muted-foreground">
+            For privacy questions or requests, email{' '}
+            <a className="text-primary underline" href="mailto:me@philgreene.net">
+              me@philgreene.net
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a clear, plain-English privacy policy reachable at `/privacy` and make it easy to find from every page via the global footer link.
- Reflect actual site practices and detected integrations so the policy stays accurate and honest about contact handling, analytics hooks, and stored preferences.

### Description
- Added a new privacy page at `client/src/pages/privacy.tsx` with `H1: Privacy Policy`, an America/New_York effective date, contact instructions pointing to `me@philgreene.net`, and the 12 required policy sections.
- Updated the shared footer `client/src/components/Footer.tsx` to include a `Privacy Policy` quick link and added `Link` from `wouter` to route internal navigation to `/privacy`.
- Updated the client router in `client/src/App.tsx` to register the `/privacy` route and adjusted layout so the footer renders on non-home routes to ensure the link is available site wide.
- Policy language reflects a repo scan: contact form posts to `/api/contact` with optional SendGrid delivery, analytics hooks for Plausible and Google Analytics exist but are only active if configured, and a local theme preference is stored in `localStorage`.

### Testing
- Ran `npm install` which completed successfully with audit output reported. 
- Ran `npm run check` (`tsc`) which passed. 
- `npm run build` failed due to an existing syntax error in `postcss.config.js`, preventing a full production build. 
- `npm run lint`, `npm test`, and `npm run format` were not available in `package.json` and therefore did not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79780c2988327b4e3499d3894949f)

## Summary by Sourcery

Add a dedicated Privacy Policy page and expose it via global navigation so users can easily access information about data collection and usage.

New Features:
- Introduce a Privacy Policy page at /privacy outlining data collection, usage, analytics, and contact details.
- Add a Privacy Policy link to the global footer for site-wide access to the policy.

Enhancements:
- Extend the client router and app layout to include the /privacy route and ensure the footer is rendered on non-home pages.