### PR TITLE
[Fix] Resolve PostCSS config syntax error blocking production build

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,4 +4,3 @@ export default {
     autoprefixer: {},
   },
 };
-}


### PR DESCRIPTION
### Motivation
- The production build was failing because `postcss.config.js` contained a syntax error (`Unexpected token '}'`) that prevented PostCSS from loading during Vercel builds.

### Description
- Removed an extra trailing `}` from `postcss.config.js` so the file now exports a valid object (`export default { plugins: { tailwindcss: {}, autoprefixer: {} } };`).

### Testing
- Ran `npm run build` and the project builds successfully (passed).
- Ran `npm run check` (`tsc`) and type checks passed (passed).
- Ran `npm audit --audit-level=critical` and no critical vulnerabilities were reported (passed); other non-critical issues remain.
- Attempted `npm run lint`, `npm test`, and `npm run format`, but those scripts are not defined in `package.json` (reported as missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79a331b448327adf9c9aa1d2d12da)

## Summary by Sourcery

Bug Fixes:
- Remove an extraneous closing brace from postcss.config.js so the PostCSS configuration is valid and no longer breaks production builds.