### PR TITLE
[Legal] Add Terms of Service page and global footer link

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import ContactSection from "@/components/ContactSection";
 import Footer from "@/components/Footer";
 import NotFound from "@/pages/not-found";
 import PrivacyPage from "@/pages/privacy";
+import TermsPage from "@/pages/terms";
 
 function HomePage() {
   const { theme, toggleTheme } = useTheme();
@@ -40,6 +41,7 @@ function AppLayout() {
       <Switch>
         <Route path="/" component={HomePage} />
         <Route path="/privacy" component={PrivacyPage} />
+        <Route path="/terms" component={TermsPage} />
         <Route component={NotFound} />
       </Switch>
       {location !== "/" && <Footer />}

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -56,7 +56,8 @@ export default function Footer() {
                 { href: '#services', label: 'Services' },
                 { href: '#projects', label: 'Projects' },
                 { href: '#contact', label: 'Contact' },
-                { href: '/privacy', label: 'Privacy Policy' }
+                { href: '/privacy', label: 'Privacy Policy' },
+                { href: '/terms', label: 'Terms of Service' }
               ].map((link) => {
                 if (link.href.startsWith('/')) {
                   return (

--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -1,0 +1,170 @@
+import { useEffect } from "react";
+
+export default function TermsPage() {
+  const effectiveDate = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date());
+
+  useEffect(() => {
+    document.title = "Terms of Service";
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Terms of Service</h1>
+          <p className="text-muted-foreground">Effective date: {effectiveDate}</p>
+          <p className="text-muted-foreground">
+            Questions about these Terms? Email{" "}
+            <a className="text-primary underline" href="mailto:me@philgreene.net">
+              me@philgreene.net
+            </a>
+            .
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">1) Acceptance of Terms</h2>
+          <p className="text-muted-foreground">
+            By accessing or using philgreene.net, you agree to these Terms of Service.
+            If you do not agree, please do not use this website.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">2) About This Website</h2>
+          <p className="text-muted-foreground">
+            philgreene.net is a personal portfolio and business website that shares
+            information about services, projects, and ways to get in touch.
+            It may include contact forms and links to third-party platforms.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">3) Eligibility</h2>
+          <p className="text-muted-foreground">
+            You must be at least 13 years old to use this website. If you are under
+            18, you should use this website with the involvement of a parent or
+            legal guardian.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">4) User Conduct</h2>
+          <ul className="list-disc pl-6 text-muted-foreground space-y-2">
+            <li>Do not use the site for unlawful, fraudulent, or harmful activity.</li>
+            <li>Do not attempt to interfere with the site, server, or networks.</li>
+            <li>Do not impersonate another person or misrepresent your identity.</li>
+            <li>
+              Do not scrape or automate requests in a way that causes abuse,
+              disruption, or unreasonable load.
+            </li>
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">5) Intellectual Property</h2>
+          <p className="text-muted-foreground">
+            Unless otherwise stated, content on this website, including text,
+            branding, graphics, and source code, is owned by philgreene.net or its
+            licensors and is protected by applicable intellectual property laws.
+            You are granted a limited, non-exclusive, non-transferable license to
+            access and use the site for personal, non-commercial use.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">6) User Content</h2>
+          <p className="text-muted-foreground">
+            If you submit information through the contact form, you represent that
+            the information is accurate and that you have the right to share it.
+            You keep ownership of your content, but you grant a limited license to
+            use it as needed to review and respond to your inquiry.
+          </p>
+          <p className="text-muted-foreground">
+            If user accounts, comments, or other upload features are added in the
+            future, additional terms may apply.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">7) Links to Third Parties</h2>
+          <p className="text-muted-foreground">
+            This website may link to third-party websites or services. Those
+            websites are controlled by third parties, and we are not responsible
+            for their content, policies, or practices.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">8) Disclaimers</h2>
+          <p className="text-muted-foreground">
+            This website is provided on an "as is" and "as available" basis,
+            without warranties of any kind, express or implied, to the fullest
+            extent permitted by law.
+          </p>
+          <p className="text-muted-foreground">
+            Content on this website is for informational purposes only and is not
+            legal, financial, medical, or other professional advice.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">9) Limitation of Liability</h2>
+          <p className="text-muted-foreground">
+            To the fullest extent permitted by law, philgreene.net and its owner
+            will not be liable for indirect, incidental, special, consequential,
+            or punitive damages, or for loss of data, profits, or business
+            opportunities arising from your use of the website.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">10) Indemnification</h2>
+          <p className="text-muted-foreground">
+            To the extent permitted by law, you agree to defend, indemnify, and
+            hold harmless philgreene.net and its owner from claims, liabilities,
+            damages, and expenses arising from your misuse of the website or your
+            violation of these Terms.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">11) Changes to the Service and Terms</h2>
+          <p className="text-muted-foreground">
+            We may update, change, or discontinue parts of the website at any time.
+            We may also revise these Terms from time to time. Updates are effective
+            when posted on this page with a revised effective date.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">12) Governing Law and Venue</h2>
+          <p className="text-muted-foreground">
+            These Terms are governed by the laws of [STATE], without regard to
+            conflict of laws rules. Any dispute will be brought in courts of
+            competent jurisdiction in [STATE].
+          </p>
+          <p className="text-muted-foreground">
+            TODO: Confirm the preferred U.S. state for governing law and venue.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">13) Contact</h2>
+          <p className="text-muted-foreground">
+            Questions about these Terms? Email{" "}
+            <a className="text-primary underline" href="mailto:me@philgreene.net">
+              me@philgreene.net
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a clear Terms of Service page so visitors can understand site rules, liabilities, and contact options. 
- Surface the Terms link site-wide via the global footer so the policy is discoverable on every page. 
- Keep language honest and scoped to detected features (contact form and email), and avoid promising features not present in the repo.

### Description
- Added a new Terms of Service page at `client/src/pages/terms.tsx` that includes an H1, effective date formatted in `America/New_York`, the contact email `me@philgreene.net` in multiple places, and the requested sections with plain, scannable language and no em dashes. 
- Registered the `/terms` route in the app router at `client/src/App.tsx` (this project uses a Vite + React app with `wouter`, not Next.js). 
- Added a `Terms of Service` link to the global footer quick links in `client/src/components/Footer.tsx` so it appears on all pages rendered by the app layout. 
- Left a clear TODO placeholder for the Governing Law state (`[STATE]`) because no authoritative jurisdiction was found in the repo, and tailored terms to detected features (contact form and email) while avoiding references to absent features like accounts or payments.

### Testing
- Ran `npm run check` (TypeScript `tsc`) and it succeeded. 
- Ran `npm audit --audit-level=critical` and it reported no critical vulnerabilities. 
- Attempted `npm run build` which failed due to an existing `postcss.config.js` syntax error unrelated to these changes. 
- Attempted `npm run lint`, `npm test`, and `npm run format` but those scripts are not present in `package.json` so they could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a799df647c8327865c662fe7f1da69)

## Summary by Sourcery

Add a dedicated Terms of Service page and expose it via routing and the global footer.

New Features:
- Introduce a Terms of Service page with dated legal terms and contact information.
- Register a new /terms route in the application router for direct access to the Terms of Service page.
- Add a Terms of Service link to the global footer so the terms are accessible from all pages.