### PR TITLE
[Compliance] Improve legal page crawlability and policy discoverability

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -69,6 +69,18 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer aria-label="Compliance links" style="padding: 1rem; border-top: 1px solid #333; font-size: 0.9rem;">
+      <p>Questions about privacy, accessibility, or website policies? Visit the pages below or get in touch.</p>
+      <nav aria-label="Legal and compliance pages" style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 0.5rem;">
+        <a href="/privacy-policy">Privacy Policy</a>
+        <a href="/terms">Terms of Service</a>
+        <a href="/cookie-policy">Cookie Policy</a>
+        <a href="/refund-policy">Refund Policy</a>
+        <a href="/disclaimer">Disclaimer</a>
+        <a href="/accessibility">Accessibility Statement</a>
+        <a href="/contact">Contact Information</a>
+      </nav>
+    </footer>
     <script type="module" src="/src/main.tsx"></script>
     <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
     <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { Switch, Route, useLocation } from "wouter";
+import { useEffect } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -14,14 +15,25 @@ import Footer from "@/components/Footer";
 import NotFound from "@/pages/not-found";
 import PrivacyPage from "@/pages/privacy";
 import TermsPage from "@/pages/terms";
+import CookiePolicyPage from "@/pages/cookie-policy";
+import RefundPolicyPage from "@/pages/refund-policy";
+import DisclaimerPage from "@/pages/disclaimer";
+import AccessibilityPage from "@/pages/accessibility";
+import ContactPage from "@/pages/contact";
 
 function HomePage() {
   const { theme, toggleTheme } = useTheme();
 
   return (
     <div className="min-h-screen">
-      <Header onThemeToggle={toggleTheme} isDark={theme === 'dark'} />
-      <main>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:bg-background focus:text-foreground focus:border focus:border-primary focus:px-3 focus:py-2 focus:rounded"
+      >
+        Skip to main content
+      </a>
+      <Header onThemeToggle={toggleTheme} isDark={theme === "dark"} />
+      <main id="main-content">
         <HeroSection />
         <AboutSection />
         <ServicesSection />
@@ -33,6 +45,16 @@ function HomePage() {
   );
 }
 
+function RedirectRoute({ to }: { to: string }) {
+  const [, navigate] = useLocation();
+
+  useEffect(() => {
+    navigate(to, { replace: true });
+  }, [navigate, to]);
+
+  return null;
+}
+
 function AppLayout() {
   const [location] = useLocation();
 
@@ -40,8 +62,36 @@ function AppLayout() {
     <div className="min-h-screen">
       <Switch>
         <Route path="/" component={HomePage} />
-        <Route path="/privacy" component={PrivacyPage} />
+
+        <Route path="/privacy-policy" component={PrivacyPage} />
+        <Route path="/privacy">
+          <RedirectRoute to="/privacy-policy" />
+        </Route>
+
         <Route path="/terms" component={TermsPage} />
+        <Route path="/terms-of-service">
+          <RedirectRoute to="/terms" />
+        </Route>
+
+        <Route path="/cookie-policy" component={CookiePolicyPage} />
+        <Route path="/cookies">
+          <RedirectRoute to="/cookie-policy" />
+        </Route>
+
+        <Route path="/refund-policy" component={RefundPolicyPage} />
+        <Route path="/returns">
+          <RedirectRoute to="/refund-policy" />
+        </Route>
+
+        <Route path="/disclaimer" component={DisclaimerPage} />
+
+        <Route path="/accessibility" component={AccessibilityPage} />
+        <Route path="/accessibility-statement">
+          <RedirectRoute to="/accessibility" />
+        </Route>
+
+        <Route path="/contact" component={ContactPage} />
+
         <Route component={NotFound} />
       </Switch>
       {location !== "/" && <Footer />}

--- a/client/src/components/ContactSection.tsx
+++ b/client/src/components/ContactSection.tsx
@@ -184,6 +184,10 @@ export default function ContactSection() {
                 <CardDescription>
                   Fill out the form below and I'll get back to you within 24 hours with a detailed proposal.
                 </CardDescription>
+                <p className="text-sm text-muted-foreground">
+                  Information submitted through this site may be used to respond to inquiries as described in the
+                  <a className="ml-1 text-primary underline" href="/privacy-policy">Privacy Policy</a>.
+                </p>
               </CardHeader>
               <CardContent>
                 <form onSubmit={handleSubmit} className="space-y-6">

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,4 +1,3 @@
-import { Link } from "wouter"
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -21,16 +20,24 @@ export default function Footer() {
     { icon: Mail, href: 'mailto:me@philgreene.net', label: 'Email' }
   ]
 
+  const legalLinks = [
+    { href: '/privacy-policy', label: 'Privacy Policy' },
+    { href: '/terms', label: 'Terms of Service' },
+    { href: '/cookie-policy', label: 'Cookie Policy' },
+    { href: '/refund-policy', label: 'Refund Policy' },
+    { href: '/disclaimer', label: 'Disclaimer' },
+    { href: '/accessibility', label: 'Accessibility' },
+    { href: '/contact', label: 'Contact' }
+  ]
+
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
-    console.log('Scrolled to top')
   }
 
   return (
-    <footer className="bg-card border-t border-border">
+    <footer className="bg-card border-t border-border" aria-label="Site footer with compliance links">
       <div className="max-w-6xl mx-auto px-4 py-16">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-          {/* Brand */}
           <div className="md:col-span-2 space-y-4">
             <div className="text-2xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
               Dev Portfolio
@@ -45,48 +52,47 @@ export default function Footer() {
                 Currently brewing: Next.js projects & ML models
               </span>
             </div>
-          </div>
-
-          {/* Quick Links */}
-          <div className="space-y-4">
-            <h3 className="font-semibold text-card-foreground">Quick Links</h3>
-            <nav className="flex flex-col space-y-2">
-              {[
-                { href: '#about', label: 'About' },
-                { href: '#services', label: 'Services' },
-                { href: '#projects', label: 'Projects' },
-                { href: '#contact', label: 'Contact' },
-                { href: '/privacy', label: 'Privacy Policy' },
-                { href: '/terms', label: 'Terms of Service' }
-              ].map((link) => {
-                if (link.href.startsWith('/')) {
-                  return (
-                    <Link
-                      key={link.href}
-                      href={link.href}
-                      className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded"
-                      data-testid={`link-footer-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
-                    >
-                      {link.label}
-                    </Link>
-                  )
-                }
-
-                return (
+            <section className="rounded-lg border border-border/60 bg-background/40 p-4 space-y-2" aria-label="Compliance and policy information">
+              <h2 className="text-sm font-semibold text-foreground">Compliance & Policy Information</h2>
+              <p className="text-sm text-muted-foreground">
+                Questions about privacy, accessibility, or website policies? Visit the pages below or get in touch.
+              </p>
+              <div className="flex flex-wrap gap-3 text-sm">
+                {legalLinks.map((link) => (
                   <a
                     key={link.href}
                     href={link.href}
-                    className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded"
-                    data-testid={`link-footer-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
+                    className="text-primary underline-offset-4 hover:underline focus-visible:underline"
                   >
                     {link.label}
                   </a>
-                )
-              })}
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="font-semibold text-card-foreground">Quick Links</h3>
+            <nav className="flex flex-col space-y-2" aria-label="Primary quick links">
+              {[
+                { href: '/#about', label: 'About' },
+                { href: '/#services', label: 'Services' },
+                { href: '/#projects', label: 'Projects' },
+                { href: '/#contact', label: 'Contact Section' },
+                ...legalLinks
+              ].map((link) => (
+                <a
+                  key={link.href + link.label}
+                  href={link.href}
+                  className="text-muted-foreground hover:text-primary transition-colors w-fit hover-elevate px-1 py-1 rounded focus-visible:underline"
+                  data-testid={`link-footer-${link.label.toLowerCase().replace(/\s+/g, '-')}`}
+                >
+                  {link.label}
+                </a>
+              ))}
             </nav>
           </div>
 
-          {/* Connect */}
           <div className="space-y-4">
             <h3 className="font-semibold text-card-foreground">Connect</h3>
             <div className="flex flex-col space-y-3">
@@ -108,7 +114,6 @@ export default function Footer() {
           </div>
         </div>
 
-        {/* Bottom Bar */}
         <div className="mt-12 pt-8 border-t border-border flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <span>© {currentYear} Dev Portfolio. Made with</span>

--- a/client/src/components/SeoHead.tsx
+++ b/client/src/components/SeoHead.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+
+interface SeoHeadProps {
+  title: string;
+  description: string;
+  canonicalPath: string;
+}
+
+export default function SeoHead({ title, description, canonicalPath }: SeoHeadProps) {
+  useEffect(() => {
+    document.title = title;
+
+    const ensureMeta = (name: string) => {
+      let tag = document.head.querySelector(`meta[name="${name}"]`) as HTMLMetaElement | null;
+      if (!tag) {
+        tag = document.createElement("meta");
+        tag.setAttribute("name", name);
+        document.head.appendChild(tag);
+      }
+      return tag;
+    };
+
+    const ensureCanonical = () => {
+      let link = document.head.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+      if (!link) {
+        link = document.createElement("link");
+        link.setAttribute("rel", "canonical");
+        document.head.appendChild(link);
+      }
+      return link;
+    };
+
+    ensureMeta("description").setAttribute("content", description);
+    ensureMeta("robots").setAttribute("content", "index, follow");
+
+    const canonicalUrl = `https://www.philgreene.net${canonicalPath}`;
+    ensureCanonical().setAttribute("href", canonicalUrl);
+  }, [canonicalPath, description, title]);
+
+  return null;
+}

--- a/client/src/pages/accessibility.tsx
+++ b/client/src/pages/accessibility.tsx
@@ -1,0 +1,36 @@
+import SeoHead from "@/components/SeoHead";
+
+export default function AccessibilityPage() {
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Accessibility Statement | Phil Greene"
+        description="Read the accessibility statement for philgreene.net and learn how to request accessibility support or report issues."
+        canonicalPath="/accessibility"
+      />
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Accessibility Statement</h1>
+          <p className="text-muted-foreground">
+            philgreene.net is committed to making this website accessible and usable for all visitors.
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Accessibility Efforts</h2>
+          <p className="text-muted-foreground">
+            We aim to provide semantic headings, meaningful links, keyboard-friendly navigation, and
+            sufficient contrast where possible.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Need Help Accessing Content?</h2>
+          <p className="text-muted-foreground">
+            If you experience an accessibility barrier, email <a className="text-primary underline" href="mailto:me@philgreene.net">me@philgreene.net</a> and include the page URL and issue details.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -1,0 +1,33 @@
+import SeoHead from "@/components/SeoHead";
+
+export default function ContactPage() {
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Contact | Phil Greene"
+        description="Contact Phil Greene for project inquiries, accessibility requests, or policy questions."
+        canonicalPath="/contact"
+      />
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Contact Information</h1>
+          <p className="text-muted-foreground">
+            Questions about privacy, accessibility, website policies, or project work? Get in touch.
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Email</h2>
+          <p className="text-muted-foreground">
+            <a className="text-primary underline" href="mailto:me@philgreene.net">me@philgreene.net</a>
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Location</h2>
+          <p className="text-muted-foreground">Manchester, New Hampshire, United States</p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/cookie-policy.tsx
+++ b/client/src/pages/cookie-policy.tsx
@@ -1,0 +1,45 @@
+import SeoHead from "@/components/SeoHead";
+
+export default function CookiePolicyPage() {
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Cookie Policy | Phil Greene"
+        description="Read the Cookie Policy for philgreene.net, including information about preference cookies and site functionality cookies."
+        canonicalPath="/cookie-policy"
+      />
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Cookie Policy</h1>
+          <p className="text-muted-foreground">
+            This Cookie Policy explains how philgreene.net uses cookies and similar technologies.
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Cookies Used on This Site</h2>
+          <p className="text-muted-foreground">
+            This site uses limited cookies and local storage for website functionality, including
+            remembering theme preferences and supporting basic site performance.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Third-Party Services</h2>
+          <p className="text-muted-foreground">
+            If third-party analytics or infrastructure providers are enabled, those services may set
+            cookies as needed to operate securely and reliably.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Managing Cookies</h2>
+          <p className="text-muted-foreground">
+            You can manage or disable cookies through your browser settings. Disabling some cookies
+            may affect functionality.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/disclaimer.tsx
+++ b/client/src/pages/disclaimer.tsx
@@ -1,0 +1,42 @@
+import SeoHead from "@/components/SeoHead";
+
+export default function DisclaimerPage() {
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Disclaimer | Phil Greene"
+        description="Read the philgreene.net disclaimer regarding informational content, third-party links, and no professional advice."
+        canonicalPath="/disclaimer"
+      />
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Disclaimer</h1>
+          <p className="text-muted-foreground">
+            The information on philgreene.net is provided for general informational purposes.
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">No Professional Advice</h2>
+          <p className="text-muted-foreground">
+            Content on this website does not constitute legal, financial, tax, or other professional advice.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Accuracy and Availability</h2>
+          <p className="text-muted-foreground">
+            While reasonable efforts are made to keep content accurate and current, no guarantees are made about completeness or availability.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Third-Party Links</h2>
+          <p className="text-muted-foreground">
+            This site may link to third-party websites. philgreene.net is not responsible for third-party content, policies, or services.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -1,3 +1,5 @@
+import SeoHead from "@/components/SeoHead";
+
 export default function PrivacyPage() {
   const effectiveDate = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York',
@@ -7,7 +9,12 @@ export default function PrivacyPage() {
   }).format(new Date())
 
   return (
-    <main className="min-h-screen bg-background text-foreground pt-24 pb-16">
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Privacy Policy | Phil Greene"
+        description="Read the Privacy Policy for philgreene.net, including what information may be collected and how it is used."
+        canonicalPath="/privacy-policy"
+      />
       <div className="max-w-3xl mx-auto px-4 space-y-8">
         <header className="space-y-3">
           <h1 className="text-4xl font-bold">Privacy Policy</h1>

--- a/client/src/pages/refund-policy.tsx
+++ b/client/src/pages/refund-policy.tsx
@@ -1,0 +1,44 @@
+import SeoHead from "@/components/SeoHead";
+
+export default function RefundPolicyPage() {
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Refund Policy | Phil Greene"
+        description="Read the Refund Policy for philgreene.net regarding digital services, timelines, and dispute handling."
+        canonicalPath="/refund-policy"
+      />
+      <div className="max-w-3xl mx-auto px-4 space-y-8">
+        <header className="space-y-3">
+          <h1 className="text-4xl font-bold">Refund Policy</h1>
+          <p className="text-muted-foreground">
+            This Refund Policy applies to services offered through philgreene.net.
+          </p>
+        </header>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Service-Based Work</h2>
+          <p className="text-muted-foreground">
+            Because services are customized and time-based, refunds are evaluated case by case based
+            on project scope, completed work, and signed agreements.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">How to Request a Review</h2>
+          <p className="text-muted-foreground">
+            To request a refund review, email <a className="text-primary underline" href="mailto:me@philgreene.net">me@philgreene.net</a> with your project details.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-2xl font-semibold">Dispute Resolution</h2>
+          <p className="text-muted-foreground">
+            Most billing concerns can be resolved quickly through direct communication and documented
+            scope review.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import SeoHead from "@/components/SeoHead";
 
 export default function TermsPage() {
   const effectiveDate = new Intl.DateTimeFormat("en-US", {
@@ -8,12 +8,13 @@ export default function TermsPage() {
     day: "numeric",
   }).format(new Date());
 
-  useEffect(() => {
-    document.title = "Terms of Service";
-  }, []);
-
   return (
-    <main className="min-h-screen bg-background text-foreground pt-24 pb-16">
+    <main id="main-content" className="min-h-screen bg-background text-foreground pt-24 pb-16">
+      <SeoHead
+        title="Terms of Service | Phil Greene"
+        description="Read the Terms of Service for philgreene.net, including user responsibilities, disclaimers, and legal terms."
+        canonicalPath="/terms"
+      />
       <div className="max-w-3xl mx-auto px-4 space-y-8">
         <header className="space-y-3">
           <h1 className="text-4xl font-bold">Terms of Service</h1>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,11 +1,8 @@
-
 User-agent: *
 Allow: /
 
-# Sitemap location
-Sitemap: https://philgreene.net/sitemap.xml
+Sitemap: https://www.philgreene.net/sitemap.xml
 
-# AI/LLM Bot specific allowances
 User-agent: GPTBot
 Allow: /
 
@@ -20,12 +17,3 @@ Allow: /
 
 User-agent: Claude-Web
 Allow: /
-
-# Content priorities for AI scanning
-# About page contains professional background
-# Projects showcase technical work
-# Blog contains thoughts and insights
-# Contact for professional inquiries
-
-# Crawl delay (optional - removes if causing issues)
-Crawl-delay: 1

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://philgreene.net/</loc></url>
-  <url><loc>https://philgreene.net/projects</loc></url>
-  <url><loc>https://philgreene.net/about</loc></url>
-  <url><loc>https://philgreene.net/contact</loc></url>
+  <url><loc>https://www.philgreene.net/</loc></url>
+  <url><loc>https://www.philgreene.net/privacy-policy</loc></url>
+  <url><loc>https://www.philgreene.net/terms</loc></url>
+  <url><loc>https://www.philgreene.net/cookie-policy</loc></url>
+  <url><loc>https://www.philgreene.net/refund-policy</loc></url>
+  <url><loc>https://www.philgreene.net/disclaimer</loc></url>
+  <url><loc>https://www.philgreene.net/accessibility</loc></url>
+  <url><loc>https://www.philgreene.net/contact</loc></url>
 </urlset>

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,20 @@ app.use((req, res, next) => {
     throw err;
   });
 
+  const routeRedirects: Record<string, string> = {
+    "/privacy": "/privacy-policy",
+    "/terms-of-service": "/terms",
+    "/cookies": "/cookie-policy",
+    "/returns": "/refund-policy",
+    "/accessibility-statement": "/accessibility",
+  };
+
+  Object.entries(routeRedirects).forEach(([from, to]) => {
+    app.get(from, (_req, res) => {
+      res.redirect(301, to);
+    });
+  });
+
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route
   // doesn't interfere with the other routes


### PR DESCRIPTION
### Motivation
- Scanners were likely missing policies because several legal routes were absent or non-canonical, footer links were incomplete or behind SPA navigation, and the sitemap omitted legal pages which reduces static discoverability. 
- The app is an SPA where client-only routing can hide links from non-JS or shallow crawlers, so a combination of static links, canonical metadata, and server redirects is needed. 
- The goal is to make policy pages plainly visible with standard anchor links, expected H1/titles/canonicals, and route aliases so automated scanners reliably find them.

### Description
- Added dedicated pages and SEO metadata for legal/compliance: `Privacy Policy`, `Terms of Service`, `Cookie Policy`, `Refund Policy`, `Disclaimer`, `Accessibility Statement`, and a `Contact` page, implemented under `client/src/pages/` and wired into the router. 
- Introduced `SeoHead` (`client/src/components/SeoHead.tsx`) to set page `title`, `meta description`, `robots`, and `canonical` for legal pages and updated `privacy.tsx` and `terms.tsx` to use it. 
- Made legal links explicit and crawlable by adding a visible compliance block and plain `<a>` links in the app footer (`client/src/components/Footer.tsx`) and a static footer with the same anchor links in the HTML shell (`client/index.html`) for non-JS crawlers, and added a privacy note to the contact form (`client/src/components/ContactSection.tsx`). 
- Normalized routes and aliases with client redirects and server-side 301 redirects (`client/src/App.tsx`, `server/index.ts`), and updated `public/sitemap.xml` and `public/robots.txt` to include the legal pages and point to the canonical sitemap. 

### Testing
- Built the project with `npm run build` which completed successfully. 
- Type-checking ran with `npm run check` (TypeScript `tsc`) and succeeded. 
- `npm audit --audit-level=critical` ran and reported no critical vulnerabilities (non-critical issues remain to triage). 
- `npm test`, `npm run lint`, and `npm run format` are not present in this repo (scripts missing), so those checks could not be executed here and are recommended to be added for CI enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e829ffc2088327a4a427a2f0f979a9)

## Summary by Sourcery

Improve discoverability and SEO of legal and compliance pages across the site, including new routes, redirects, and metadata.

New Features:
- Add dedicated pages for cookie policy, refund policy, disclaimer, accessibility statement, and contact information with appropriate legal copy and structure.
- Introduce a reusable SeoHead component to manage titles, meta tags, and canonical URLs for key pages.
- Expose a persistent compliance and policy section in the main footer and static HTML footer with direct links to all legal pages.

Enhancements:
- Normalize and alias legal routes in the SPA router with client-side redirects for legacy paths.
- Add server-side 301 redirects for legacy legal URLs to their canonical counterparts.
- Update sitemap entries to include all legal and contact pages under the canonical www domain.
- Improve accessibility with a skip-to-content link and ARIA labels on footer navigation and compliance sections.
- Clarify contact form usage of submitted information by linking to the Privacy Policy.