### PR TITLE
Store contact form submissions in database (Final)

### DIFF
--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { sendEmail } from '../server/sendgrid';
+import { storage } from '../server/storage';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Only allow POST requests
@@ -74,6 +75,9 @@ Submitted at: ${new Date().toISOString()}
         timestamp: new Date().toISOString()
       });
     }
+
+    // Store in database for backup
+    await storage.insertContactSubmission({ name, email, projectType, budget, message });
 
     return res.json({ ok: true });
   } catch (error) {

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,17 @@
+import { neon, neonConfig } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
+import ws from 'ws';
+import * as schema from '@shared/schema';
+
+// Required for Neon serverless in certain environments
+if (process.env.NODE_ENV !== 'production') {
+  neonConfig.webSocketConstructor = ws;
+}
+
+if (!process.env.DATABASE_URL) {
+  // We can't throw here if we want the app to start without a DB (fallback to MemStorage)
+  // But we need to ensure the exports are still valid types.
+}
+
+export const sql = process.env.DATABASE_URL ? neon(process.env.DATABASE_URL) : null;
+export const db = sql ? drizzle(sql, { schema }) : null;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,12 +1,6 @@
-import { neon, neonConfig } from '@neondatabase/serverless';
+import { neon } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-http';
-import ws from 'ws';
 import * as schema from '@shared/schema';
-
-// Required for Neon serverless in certain environments
-if (process.env.NODE_ENV !== 'production') {
-  neonConfig.webSocketConstructor = ws;
-}
 
 if (!process.env.DATABASE_URL) {
   // We can't throw here if we want the app to start without a DB (fallback to MemStorage)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -74,8 +74,8 @@ Submitted at: ${new Date().toISOString()}
         });
       }
 
-      // TODO: Consider storing in database for backup
-      // storage.insertContactSubmission({ name, email, projectType, budget, message });
+      // Store in database for backup
+      await storage.insertContactSubmission({ name, email, projectType, budget, message });
 
       return res.json({ ok: true });
     } catch (error) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,20 +1,61 @@
-import { type User, type InsertUser } from "@shared/schema";
+import {
+  type User,
+  type InsertUser,
+  type ContactSubmission,
+  type InsertContactSubmission,
+  users,
+  contactSubmissions
+} from "@shared/schema";
 import { randomUUID } from "crypto";
+import { db } from "./db";
+import { eq } from "drizzle-orm";
 
-// modify the interface with any CRUD methods
-// you might need
+if (!db && process.env.DATABASE_URL) {
+  throw new Error("Database connection failed despite DATABASE_URL being present");
+}
 
 export interface IStorage {
   getUser(id: string): Promise<User | undefined>;
   getUserByUsername(username: string): Promise<User | undefined>;
   createUser(user: InsertUser): Promise<User>;
+
+  // Contact submission
+  insertContactSubmission(submission: InsertContactSubmission): Promise<ContactSubmission>;
+}
+
+export class DatabaseStorage implements IStorage {
+  async getUser(id: string): Promise<User | undefined> {
+    if (!db) throw new Error("Database not initialized");
+    const [user] = await db.select().from(users).where(eq(users.id, id));
+    return user;
+  }
+
+  async getUserByUsername(username: string): Promise<User | undefined> {
+    if (!db) throw new Error("Database not initialized");
+    const [user] = await db.select().from(users).where(eq(users.username, username));
+    return user;
+  }
+
+  async createUser(insertUser: InsertUser): Promise<User> {
+    if (!db) throw new Error("Database not initialized");
+    const [user] = await db.insert(users).values(insertUser).returning();
+    return user;
+  }
+
+  async insertContactSubmission(submission: InsertContactSubmission): Promise<ContactSubmission> {
+    if (!db) throw new Error("Database not initialized");
+    const [result] = await db.insert(contactSubmissions).values(submission).returning();
+    return result;
+  }
 }
 
 export class MemStorage implements IStorage {
   private users: Map<string, User>;
+  private submissions: Map<string, ContactSubmission>;
 
   constructor() {
     this.users = new Map();
+    this.submissions = new Map();
   }
 
   async getUser(id: string): Promise<User | undefined> {
@@ -33,6 +74,21 @@ export class MemStorage implements IStorage {
     this.users.set(id, user);
     return user;
   }
+
+  async insertContactSubmission(submission: InsertContactSubmission): Promise<ContactSubmission> {
+    const id = randomUUID();
+    const result: ContactSubmission = {
+      ...submission,
+      id,
+      projectType: submission.projectType ?? null,
+      budget: submission.budget ?? null,
+      sentAt: new Date()
+    };
+    this.submissions.set(id, result);
+    return result;
+  }
 }
 
-export const storage = new MemStorage();
+export const storage = process.env.DATABASE_URL
+  ? new DatabaseStorage()
+  : new MemStorage();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, text, varchar } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -16,3 +16,24 @@ export const insertUserSchema = createInsertSchema(users).pick({
 
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type User = typeof users.$inferSelect;
+
+export const contactSubmissions = pgTable("contact_submissions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  email: text("email").notNull(),
+  projectType: text("project_type"),
+  budget: text("budget"),
+  message: text("message").notNull(),
+  sentAt: timestamp("sent_at").notNull().defaultNow(),
+});
+
+export const insertContactSubmissionSchema = createInsertSchema(contactSubmissions).pick({
+  name: true,
+  email: true,
+  projectType: true,
+  budget: true,
+  message: true,
+});
+
+export type InsertContactSubmission = z.infer<typeof insertContactSubmissionSchema>;
+export type ContactSubmission = typeof contactSubmissions.$inferSelect;


### PR DESCRIPTION
Final submission of the contact form database storage feature. All feedback has been addressed, and the implementation is robust and follows project conventions.

---
*PR created automatically by Jules for task [5831199930155900990](https://jules.google.com/task/5831199930155900990) started by @WebCraftPhil*

## Summary by Sourcery

Persist contact form submissions using a database-backed storage layer with an in-memory fallback.

New Features:
- Add contactSubmissions table schema and associated insert/select types for contact form data.
- Store incoming contact form submissions from both serverless and Express-style handlers in persistent storage.

Enhancements:
- Introduce a DatabaseStorage implementation backed by Drizzle ORM/Neon and select it at runtime when DATABASE_URL is configured, falling back to MemStorage otherwise.
- Extend the shared storage interface and in-memory storage to support contact form submission records alongside users.
- Add a shared db module to initialize the Drizzle ORM client and handle optional database availability.