### PR TITLE
Update Terms of Service governing law and venue to New Hampshire

### DIFF
--- a/client/src/pages/terms.tsx
+++ b/client/src/pages/terms.tsx
@@ -146,12 +146,9 @@ export default function TermsPage() {
         <section className="space-y-2">
           <h2 className="text-2xl font-semibold">12) Governing Law and Venue</h2>
           <p className="text-muted-foreground">
-            These Terms are governed by the laws of [STATE], without regard to
+            These Terms are governed by the laws of the State of New Hampshire, without regard to
             conflict of laws rules. Any dispute will be brought in courts of
-            competent jurisdiction in [STATE].
-          </p>
-          <p className="text-muted-foreground">
-            TODO: Confirm the preferred U.S. state for governing law and venue.
+            competent jurisdiction in the State of New Hampshire.
           </p>
         </section>
 


### PR DESCRIPTION
Set Section 12 of the Terms of Service (client/src/pages/terms.tsx) to specify the State of New Hampshire as the governing law and venue, and removed the TODO note.

---
*PR created automatically by Jules for task [8142215663587887281](https://jules.google.com/task/8142215663587887281) started by @WebCraftPhil*

## Summary by Sourcery

Enhancements:
- Specify New Hampshire as the governing law and venue for the Terms of Service.