### PR TITLE
⚡ Optimize target resolution in redirect loop inside safeFetchHtml

### DIFF
--- a/server/scanner/safe-fetch.ts
+++ b/server/scanner/safe-fetch.ts
@@ -142,7 +142,7 @@ export function isPublicIp(address: string) {
   return false
 }
 
-async function resolvePublicTarget(url: URL, dnsCache?: Map<string, LookupAddress>) {
+function validateTargetUrl(url: URL): string {
   if (!['http:', 'https:'].includes(url.protocol)) throw new SafeFetchError('Only http and https websites can be scanned.')
   if (url.username || url.password) throw new SafeFetchError('Website addresses cannot include a username or password.')
   if (url.port && !['80', '443'].includes(url.port)) throw new SafeFetchError('That website uses a port the scanner cannot access.')
@@ -150,6 +150,11 @@ async function resolvePublicTarget(url: URL, dnsCache?: Map<string, LookupAddres
   if (hostname === 'localhost' || hostname.endsWith('.localhost') || net.isIP(hostname)) {
     throw new SafeFetchError('Private network and direct IP addresses cannot be scanned.')
   }
+  return hostname
+}
+
+async function resolvePublicTarget(url: URL, dnsCache?: Map<string, LookupAddress>) {
+  const hostname = validateTargetUrl(url)
   const cached = dnsCache?.get(hostname)
   if (cached) {
     return cached
@@ -215,9 +220,24 @@ export async function safeFetchHtml(input: string) {
   let url = normalizeWebsiteUrl(input)
   const requestedUrl = url.toString()
   const dnsCache = new Map<string, LookupAddress>()
+  let currentHostname = ''
+  let currentTarget: LookupAddress | null = null
 
   for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect += 1) {
-    const target = await resolvePublicTarget(url, dnsCache)
+    const hostname = validateTargetUrl(url)
+    let target: LookupAddress
+    if (currentTarget && hostname === currentHostname) {
+      target = currentTarget
+    } else {
+      const cached = dnsCache.get(hostname)
+      if (cached) {
+        target = cached
+      } else {
+        target = await resolvePublicTarget(url, dnsCache)
+      }
+      currentHostname = hostname
+      currentTarget = target
+    }
     const response = await requestHtml(url, target)
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       const location = response.headers.location


### PR DESCRIPTION
💡 **What:** Refactored URL target validation and resolution in `server/scanner/safe-fetch.ts`. Extracted synchronous URL validation (`validateTargetUrl`) and optimized `safeFetchHtml` to reuse the already resolved target synchronously when a redirect remains on the same hostname.

🎯 **Why:** Previously, each redirect step inside `safeFetchHtml` awaited `resolvePublicTarget` sequentially even when the target hostname was unchanged (e.g. `http://example.com` -> `https://example.com`). This incurred unnecessary async overhead and Map cache queries.

📊 **Measured Improvement:** Verified that target resolution is reused across redirects without redundant async calls, preserving all security checks (IP range filtering, port restrictions, protocol validation).

---
*PR created automatically by Jules for task [17261779274626158988](https://jules.google.com/task/17261779274626158988) started by @WebCraftPhil*

## Summary by Sourcery

Reduce redundant target resolution during safe HTML fetch redirects while retaining URL and network safety validation.

Enhancements:
- Optimize redirect handling in `safeFetchHtml` by reusing validated target resolution when redirects stay on the same hostname.
- Separate synchronous URL validation from DNS target resolution while preserving existing scanning security checks.