### PR TITLE
🎨 Palette: enhance accessibility in GuidedLeadAssistant

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Form inputs and progress indicators in modal checkup assistant
+**Learning:** Modal wizard steps with descriptive hint text (`<small>`) and custom progress bars need explicit `aria-describedby` associations and `role="progressbar"` attributes to properly inform screen reader users of field context and step progression.
+**Action:** Link hint text using `aria-describedby` and add full progressbar ARIA attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`, `aria-valuetext`) to progress containers in wizard components.

--- a/client/src/components/GuidedLeadAssistant.tsx
+++ b/client/src/components/GuidedLeadAssistant.tsx
@@ -100,13 +100,17 @@ export default function GuidedLeadAssistant({ onComplete }: Props) {
               <button ref={closeRef} type="button" onClick={closeAssistant} aria-label="Close Website Checkup"><X aria-hidden="true" /></button>
             </div>
             <p id="assistant-description" className="assistant-privacy">Four quick questions. Your answers stay in this browser until you choose to submit the audit form.</p>
-            <div className="assistant-progress" aria-label={`Step ${Math.min(step + 1, 5)} of 5`}><span style={{ width: `${((step + 1) / 5) * 100}%` }} /></div>
+            <div className="assistant-progress" aria-label="Website Checkup navigation" role="progressbar" aria-valuenow={Math.min(step + 1, 5)} aria-valuemin={1} aria-valuemax={5} aria-valuetext={`Step ${Math.min(step + 1, 5)} of 5`}><span style={{ width: `${((step + 1) / 5) * 100}%` }} /></div>
 
             <div className="assistant-body">
               {step === 0 && (
                 <label className="assistant-field">
                   <span>What kind of business do you run?</span>
-                  <select value={answers.businessType} onChange={(event) => setAnswers((current) => ({ ...current, businessType: event.target.value }))}>
+                  <select
+                    value={answers.businessType}
+                    aria-required="true"
+                    onChange={(event) => setAnswers((current) => ({ ...current, businessType: event.target.value }))}
+                  >
                     <option value="">Choose a business type</option>
                     {businessTypes.map((type) => <option key={type} value={type}>{type}</option>)}
                   </select>
@@ -115,8 +119,15 @@ export default function GuidedLeadAssistant({ onComplete }: Props) {
               {step === 1 && (
                 <label className="assistant-field">
                   <span>What is your website address?</span>
-                  <input type="url" inputMode="url" placeholder="https://yourbusiness.com (optional)" value={answers.websiteUrl} onChange={(event) => setAnswers((current) => ({ ...current, websiteUrl: event.target.value }))} />
-                  <small>No website yet? Leave this blank and continue.</small>
+                  <input
+                    type="url"
+                    inputMode="url"
+                    placeholder="https://yourbusiness.com (optional)"
+                    value={answers.websiteUrl}
+                    aria-describedby="assistant-website-url-hint"
+                    onChange={(event) => setAnswers((current) => ({ ...current, websiteUrl: event.target.value }))}
+                  />
+                  <small id="assistant-website-url-hint">No website yet? Leave this blank and continue.</small>
                 </label>
               )}
               {step === 2 && <ChoiceQuestion legend="What would you most like to improve?" value={answers.primaryGoal} onChange={(primaryGoal) => setAnswers((current) => ({ ...current, primaryGoal }))} options={[


### PR DESCRIPTION
🎨 **Palette: Enhance accessibility in GuidedLeadAssistant**

### 💡 What
Improved accessibility for the `GuidedLeadAssistant` component:
- Added `aria-required="true"` to the mandatory business type selection dropdown.
- Linked the optional website URL input field with its helper/hint text (`<small>`) using `aria-describedby` and an `id`.
- Added `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-valuetext` to the progress indicator container.

### 🎯 Why
Screen reader users navigating the guided checkup modal need clear feedback on step progress, required input fields, and contextual helper text.

### ♿ Accessibility
- Enables assistive technologies to read out helper/hint text when focusing on the website URL input.
- Accurately announces progress changes across modal steps.
- Indicates mandatory field expectations clearly to screen reader users.

---
*PR created automatically by Jules for task [8773741868797535034](https://jules.google.com/task/8773741868797535034) started by @WebCraftPhil*

## Summary by Sourcery

Improve GuidedLeadAssistant accessibility for screen reader users navigating form fields and wizard progress.

Enhancements:
- Improve GuidedLeadAssistant accessibility by exposing required-field semantics, website input guidance, and current wizard progress to assistive technologies.

Chores:
- Record accessibility guidance for modal form inputs and progress indicators.