### PR TITLE
🎨 Palette: Add aria-expanded attribute to GuidedLeadAssistant trigger

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Modal Focus Trapping and Focus Restoration
+**Learning:** Custom overlay dialogs (like `GuidedLeadAssistant`) must explicitly trap keyboard focus (`Tab`/`Shift+Tab`) within the modal container and restore focus to the trigger button when closed. Without this, screen readers and keyboard users tab into hidden background page elements behind the backdrop.
+**Action:** Always attach keydown listeners in modal components to restrict tab navigation to internal focusable elements and refocus `triggerRef` on dismiss.

--- a/client/src/components/GuidedLeadAssistant.tsx
+++ b/client/src/components/GuidedLeadAssistant.tsx
@@ -84,7 +84,7 @@ export default function GuidedLeadAssistant({ onComplete }: Props) {
 
   return (
     <>
-      <button ref={triggerRef} className="checkup-trigger" type="button" onClick={openAssistant} aria-haspopup="dialog">
+      <button ref={triggerRef} className="checkup-trigger" type="button" onClick={openAssistant} aria-haspopup="dialog" aria-expanded={isOpen}>
         <MessageSquareText aria-hidden="true" />
         <span><strong>Website Checkup</strong><small>Find your best next step</small></span>
       </button>


### PR DESCRIPTION
Added aria-expanded={isOpen} attribute to the GuidedLeadAssistant trigger button so screen readers correctly announce the open/closed state of the modal dialog.

---
*PR created automatically by Jules for task [17900628197869359561](https://jules.google.com/task/17900628197869359561) started by @WebCraftPhil*

## Summary by Sourcery

Improve GuidedLeadAssistant accessibility by communicating the modal trigger’s current state to screen readers.

Bug Fixes:
- Expose the GuidedLeadAssistant trigger’s expanded or collapsed state to assistive technologies.

Chores:
- Record accessibility guidance for modal focus management in the project’s Jules notes.