### PR TITLE
🎨 Palette: improve mobile menu button aria-label clarity

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -62,7 +62,7 @@ export default function Header() {
           type="button"
           aria-expanded={isOpen}
           aria-controls="mobile-navigation"
-          aria-label={isOpen ? 'Close navigation' : 'Open navigation'}
+          aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
           onClick={() => setIsOpen((current) => !current)}
         >
           {isOpen ? <X aria-hidden="true" /> : <Menu aria-hidden="true" />}


### PR DESCRIPTION
🎨 Palette: Improve Mobile Navigation Menu ARIA Label Clarity

💡 What: Updated the `aria-label` attribute on the mobile navigation toggle button in `Header.tsx` from "Open/Close navigation" to "Open/Close navigation menu".
🎯 Why: Provides clearer and more explicit context for screen reader users when toggling the mobile header menu.
♿ Accessibility: Improved screen reader descriptive text on an interactive icon-only control.

---
*PR created automatically by Jules for task [4566446714696774123](https://jules.google.com/task/4566446714696774123) started by @WebCraftPhil*

## Summary by Sourcery

Enhancements:
- Clarify the mobile navigation toggle’s accessible label for screen reader users.